### PR TITLE
Add Clerk authentication pages and redirect

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,6 @@
+import EventShowcase from '@/components/EventShowcase';
+
+export default function EventsPage() {
+  return <EventShowcase />;
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ClerkProvider } from "@clerk/nextjs";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,12 +24,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
-    </html>
+    <ClerkProvider>
+      <html lang="en">
+        <body
+          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        >
+          {children}
+        </body>
+      </html>
+    </ClerkProvider>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,13 @@
-import EventShowcase from '@/components/EventShowcase';
+import { auth } from '@clerk/nextjs/server';
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return <EventShowcase />;
+  const { userId } = auth();
+
+  if (userId) {
+    redirect('/events');
+  }
+
+  redirect('/sign-in');
 }
+

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,10 @@
+import { SignIn } from '@clerk/nextjs';
+
+export default function Page() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <SignIn />
+    </div>
+  );
+}
+

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,10 @@
+import { SignUp } from '@clerk/nextjs';
+
+export default function Page() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <SignUp />
+    </div>
+  );
+}
+

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@clerk/nextjs": "^5",
+    "next": "15.4.5",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.5"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- integrate ClerkProvider and add Clerk auth pages
- redirect root to /events or /sign-in based on authentication
- move event showcase to /events route

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_688db828467c8321a47b141fa2884658