### PR TITLE
Use Clerk to load user tier

### DIFF
--- a/app/api/default-tier/route.ts
+++ b/app/api/default-tier/route.ts
@@ -1,0 +1,14 @@
+import { auth, clerkClient } from '@clerk/nextjs/server';
+
+export async function POST() {
+  const { userId } = auth();
+  if (!userId) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  await clerkClient.users.updateUserMetadata(userId, {
+    publicMetadata: { tier: 'Free' },
+  });
+
+  return Response.json({ tier: 'Free' });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Providers } from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +25,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ClerkProvider } from '@clerk/nextjs';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return <ClerkProvider>{children}</ClerkProvider>;
+}

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useUser } from '@clerk/nextjs';
 import events, { Tier } from '@/data/events';
-
-const tiers: Tier[] = ['Free', 'Silver', 'Gold', 'Platinum'];
 
 const tierRank: Record<Tier, number> = {
   Free: 0,
@@ -13,7 +11,8 @@ const tierRank: Record<Tier, number> = {
 };
 
 export default function EventShowcase() {
-  const [tier, setTier] = useState<Tier>('Free');
+  const { user } = useUser();
+  const tier = (user?.publicMetadata?.tier as Tier) || 'Free';
 
   const filtered = events.filter(
     (event) => tierRank[event.tier] <= tierRank[tier]
@@ -23,21 +22,7 @@ export default function EventShowcase() {
     <div className="p-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
       <div className="mb-6 text-center">
-        <label htmlFor="tier" className="mr-2 font-medium">
-          Select your tier:
-        </label>
-        <select
-          id="tier"
-          value={tier}
-          onChange={(e) => setTier(e.target.value as Tier)}
-          className="border rounded px-2 py-1 bg-background text-foreground"
-        >
-          {tiers.map((t) => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
+        <p className="font-medium">Your tier: {tier}</p>
       </div>
       <ul className="grid gap-4">
         {filtered.length ? (

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.4.5"
+    "next": "15.4.5",
+    "@clerk/nextjs": "^5.3.3"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
- wrap app in Clerk provider and use Clerk's `useUser` hook to read `publicMetadata.tier`
- display events allowed for the user's tier
- add API endpoint to set new users' tier to Free and add Clerk dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688db9ffa8ec8321953b018432015128