### PR TITLE
chore: initialize supabase schema

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,4 @@
+project_id = ""
+
+[db]
+major_version = 15

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,19 @@
+-- Enable UUID extension for generating UUID v4 values
+create extension if not exists "uuid-ossp";
+
+-- Enum type to represent event tiers
+create type tier_enum as enum (
+  'free',
+  'silver',
+  'gold',
+  'platinum'
+);
+
+-- Events table storing tiered events
+create table events (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  description text not null,
+  tier tier_enum not null,
+  created_at timestamptz not null default now()
+);


### PR DESCRIPTION
## Summary
- add Supabase config scaffold
- define tier enum and events table schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint config; not run)*
- `psql -f supabase/schema.sql` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dbbaf8418832190f9725a174c67d5