### PR TITLE
Add Supabase seed script with sample events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Database Seeding
+
+Sample event data is available in [`supabase/seed.sql`](supabase/seed.sql). It inserts two example events for each membership tier with titles, descriptions, dates, and image URLs. Run the seed with the [Supabase CLI](https://supabase.com/docs/guides/cli) after linking your project:
+
+```bash
+supabase db seed
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,11 @@
+-- Seed data for events
+INSERT INTO events (title, description, event_date, image_url, tier)
+VALUES
+  ('Community Meetup', 'Meet fellow members at our free meetup.', '2024-03-01', 'https://example.com/images/community-meetup.jpg', 'Free'),
+  ('All Hands Q&A', 'Monthly Q&A open for all tiers.', '2024-03-15', 'https://example.com/images/all-hands-qa.jpg', 'Free'),
+  ('Silver Webinar', 'Exclusive webinar for Silver members.', '2024-04-10', 'https://example.com/images/silver-webinar.jpg', 'Silver'),
+  ('Silver Workshop', 'Hands-on workshop to sharpen your skills.', '2024-04-20', 'https://example.com/images/silver-workshop.jpg', 'Silver'),
+  ('Gold Hackathon', 'Join our 24h hackathon and win prizes.', '2024-05-05', 'https://example.com/images/gold-hackathon.jpg', 'Gold'),
+  ('Gold Networking Night', 'Networking event for Gold and Platinum members.', '2024-05-18', 'https://example.com/images/gold-networking-night.jpg', 'Gold'),
+  ('Platinum Retreat', 'A weekend retreat for our Platinum members.', '2024-06-07', 'https://example.com/images/platinum-retreat.jpg', 'Platinum'),
+  ('Platinum Gala', 'Formal gala dinner for Platinum supporters.', '2024-06-21', 'https://example.com/images/platinum-gala.jpg', 'Platinum');


### PR DESCRIPTION
## Summary
- add `supabase/seed.sql` with two demo events for each membership tier
- document how to run the seed in the README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompted for ESLint configuration and did not run)*
- `npx supabase --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*

------
https://chatgpt.com/codex/tasks/task_e_688dbce433688321963bd1186b3c3f28