### PR TITLE
feat: add seed data for events

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,9 @@
+insert into public.events (title, description, tier, event_date, image_url) values
+  ('Community Kickoff', 'Meet fellow free members.', 'Free', '2025-09-01', 'https://example.com/images/free1.jpg'),
+  ('Open Source Sprint', 'Collaborate on open source projects.', 'Free', '2025-09-15', 'https://example.com/images/free2.jpg'),
+  ('Silver Strategy Session', 'Exclusive webinar for Silver tier.', 'Silver', '2025-10-05', 'https://example.com/images/silver1.jpg'),
+  ('Silver Networking Hour', 'Connect with peers at this virtual event.', 'Silver', '2025-10-20', 'https://example.com/images/silver2.jpg'),
+  ('Gold Hackathon', '24-hour hackathon with prizes.', 'Gold', '2025-11-10', 'https://example.com/images/gold1.jpg'),
+  ('Gold Masterclass', 'Deep dive masterclass for Gold members.', 'Gold', '2025-11-25', 'https://example.com/images/gold2.jpg'),
+  ('Platinum Retreat', 'Weekend retreat for Platinum members.', 'Platinum', '2025-12-05', 'https://example.com/images/platinum1.jpg'),
+  ('Platinum Gala', 'End-of-year gala dinner.', 'Platinum', '2025-12-20', 'https://example.com/images/platinum2.jpg');


### PR DESCRIPTION
## Summary
- add SQL seed script inserting sample events for each membership tier

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for Next.js ESLint configuration)*
- `npm install -g supabase` *(fails: 403 Forbidden)*
- `psql "$NEXT_PUBLIC_SUPABASE_URL" -f supabase/seed.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688dbce433688321963bd1186b3c3f28