### PR TITLE
Handle errors from getEventsForTier

### DIFF
--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { useUser } from "@clerk/nextjs";
-import events, { Tier } from "@/data/events";
-
-const tierRank: Record<Tier, number> = {
-  Free: 0,
-  Silver: 1,
-  Gold: 2,
-  Platinum: 3,
-};
+import { getEventsForTier, Tier } from "@/data/events";
 
 export default function EventShowcase() {
   const { user, isLoaded, isSignedIn } = useUser();
@@ -20,9 +13,15 @@ export default function EventShowcase() {
   const tier: Tier =
     (isSignedIn ? (user?.publicMetadata?.tier as Tier) : undefined) ?? "Free";
 
-  const filtered = events.filter(
-    (event) => tierRank[event.tier] <= tierRank[tier]
-  );
+  const { events: filtered, error } = getEventsForTier(tier);
+
+  if (error) {
+    return (
+      <div className="p-4 max-w-2xl mx-auto">
+        Failed to load events: {error}
+      </div>
+    );
+  }
 
   return (
     <div className="p-4 max-w-2xl mx-auto">

--- a/data/events.ts
+++ b/data/events.ts
@@ -46,4 +46,29 @@ const events: Event[] = [
   },
 ];
 
+export const tierRank: Record<Tier, number> = {
+  Free: 0,
+  Silver: 1,
+  Gold: 2,
+  Platinum: 3,
+};
+
+export function getEventsForTier(tier: Tier): {
+  events: Event[];
+  error: string | null;
+} {
+  try {
+    if (!(tier in tierRank)) {
+      throw new Error(`Invalid tier: ${tier}`);
+    }
+    const filtered = events.filter(
+      (event) => tierRank[event.tier] <= tierRank[tier]
+    );
+    return { events: filtered, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return { events: [], error: message };
+  }
+}
+
 export default events;


### PR DESCRIPTION
## Summary
- add getEventsForTier helper that validates tiers and returns errors
- use getEventsForTier in EventShowcase component to surface fetch errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for configuration)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688df18d859083219348e4972b8bac13