### PR TITLE
Add authenticated navigation bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
+import Navbar from "@/components/Navbar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,6 +30,7 @@ export default function RootLayout({
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
+          <Navbar />
           {children}
         </body>
       </html>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { useUser, UserButton, SignOutButton } from '@clerk/nextjs';
+
+export default function Navbar() {
+  const { isSignedIn } = useUser();
+
+  return (
+    <nav className="flex items-center justify-between p-4 border-b">
+      <Link href="/" className="flex items-center space-x-2">
+        <Image src="/file.svg" alt="App logo" width={32} height={32} />
+        <span className="font-semibold">Event Showcase</span>
+      </Link>
+      <div className="flex items-center gap-4">
+        {isSignedIn ? (
+          <>
+            <Link href="/events" className="hover:underline">
+              Events
+            </Link>
+            <UserButton appearance={{ elements: { avatarBox: 'h-8 w-8' } }} />
+            <SignOutButton>
+              <button className="px-3 py-1 text-sm rounded bg-gray-200 hover:bg-gray-300">
+                Sign out
+              </button>
+            </SignOutButton>
+          </>
+        ) : (
+          <>
+            <Link href="/sign-in" className="hover:underline">
+              Sign in
+            </Link>
+            <Link href="/sign-up" className="hover:underline">
+              Sign up
+            </Link>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add navbar with app logo, avatar, and sign-out button
- protect links based on sign-in status
- include navbar in root layout for site-wide navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_688df46228408321b1ee0713ab3a2d13