### PR TITLE
feat: add spinner and error components

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import ErrorMessage from '@/components/ErrorMessage';
+
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return <ErrorMessage message={error.message} onRetry={reset} />;
+}

--- a/app/events/error.tsx
+++ b/app/events/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { useEffect } from 'react';
+import ErrorMessage from '@/components/ErrorMessage';
+
+export default function EventsError({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return <ErrorMessage message={error.message} onRetry={reset} />;
+}

--- a/app/events/loading.tsx
+++ b/app/events/loading.tsx
@@ -1,0 +1,5 @@
+import Spinner from '@/components/Spinner';
+
+export default function Loading() {
+  return <Spinner />;
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+import Spinner from '@/components/Spinner';
+
+export default function Loading() {
+  return <Spinner />;
+}

--- a/components/ErrorMessage.tsx
+++ b/components/ErrorMessage.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+interface ErrorMessageProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export default function ErrorMessage({ message = 'Something went wrong.', onRetry }: ErrorMessageProps) {
+  return (
+    <div className="p-4 text-center">
+      <p className="mb-4 text-red-600">{message}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="px-4 py-2 bg-red-500 text-white rounded"
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -2,6 +2,7 @@
 
 import { useUser } from "@clerk/nextjs";
 import events, { Tier } from "@/data/events";
+import Spinner from "@/components/Spinner";
 
 const tierRank: Record<Tier, number> = {
   Free: 0,
@@ -14,7 +15,7 @@ export default function EventShowcase() {
   const { user, isLoaded, isSignedIn } = useUser();
 
   if (!isLoaded) {
-    return <div className="p-4 max-w-2xl mx-auto">Loading events...</div>;
+    return <Spinner />;
   }
 
   const tier: Tier =

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,0 +1,25 @@
+export default function Spinner() {
+  return (
+    <div className="flex items-center justify-center p-4" role="status" aria-label="Loading">
+      <svg
+        className="animate-spin h-8 w-8 text-gray-600"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+          fill="none"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Spinner component for loading indicators
- add ErrorMessage component with retry support
- wire up app and events routes with loading and error boundaries
- show spinner while the current user's info loads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_688df6d754088321a9706541524dd36e