### PR TITLE
feat: add tier badge component

### DIFF
--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -2,6 +2,7 @@
 
 import { useUser } from "@clerk/nextjs";
 import events, { Tier } from "@/data/events";
+import TierBadge from "@/components/TierBadge";
 
 const tierRank: Record<Tier, number> = {
   Free: 0,
@@ -41,9 +42,7 @@ export default function EventShowcase() {
               <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
                 {event.description}
               </p>
-              <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-                {event.tier} tier
-              </span>
+              <TierBadge tier={event.tier} />
             </li>
           ))
         ) : (

--- a/components/TierBadge.tsx
+++ b/components/TierBadge.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Tier } from '@/data/events';
+
+interface TierBadgeProps {
+  tier: Tier;
+}
+
+const tierStyles: Record<Tier, string> = {
+  Free: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  Silver: 'bg-slate-300 text-slate-800 dark:bg-slate-600 dark:text-slate-100',
+  Gold: 'bg-yellow-200 text-yellow-800 dark:bg-yellow-600 dark:text-yellow-100',
+  Platinum:
+    'bg-purple-200 text-purple-800 dark:bg-purple-600 dark:text-purple-100',
+};
+
+export default function TierBadge({ tier }: TierBadgeProps) {
+  return (
+    <span className={`text-xs px-2 py-1 rounded ${tierStyles[tier]}`}>
+      {tier} tier
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add TierBadge component with color mapping for tiers
- use TierBadge in EventShowcase to display event tier

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` font)*

------
https://chatgpt.com/codex/tasks/task_e_688df8a7b79483219bc57e721bbdfe6a