### PR TITLE
feat: load tiered events via supabase

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,6 +1,78 @@
-import EventShowcase from '@/components/EventShowcase';
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth, useUser } from '@clerk/nextjs';
+import { useRouter } from 'next/navigation';
+import Spinner from '@/components/Spinner';
+import ErrorMessage from '@/components/ErrorMessage';
+import EventCard, { Event } from '@/components/EventCard';
+import { getEventsForTier } from '@/lib/events';
+
+const tierMap: Record<string, number> = {
+  Free: 0,
+  Silver: 1,
+  Gold: 2,
+  Platinum: 3,
+};
 
 export default function EventsPage() {
-  return <EventShowcase />;
-}
+  const { isLoaded, isSignedIn } = useAuth();
+  const { user } = useUser();
+  const router = useRouter();
 
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEvents = async () => {
+    try {
+      setError(null);
+      setLoading(true);
+      const tierName = (user?.publicMetadata?.tier as string) || 'Free';
+      const tierValue = tierMap[tierName] ?? 0;
+      const data = await getEventsForTier(tierValue);
+      setEvents(data);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isLoaded) return;
+    if (!isSignedIn) {
+      router.push('/sign-in?redirect_url=/events');
+      return;
+    }
+    fetchEvents();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded, isSignedIn]);
+
+  if (!isLoaded || !isSignedIn) {
+    return <Spinner />;
+  }
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={fetchEvents} />;
+  }
+
+  if (!events.length) {
+    return <p className="p-4 text-center">No events available for your tier.</p>;
+  }
+
+  return (
+    <div className="p-4 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {events.map((event) => (
+          <EventCard key={event.id} event={event} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react';
+
+export interface Event {
+  id: number;
+  name: string;
+  description: string;
+  tier: number;
+  event_date?: string;
+}
+
+const tierLabels = ['Free', 'Silver', 'Gold', 'Platinum'];
+
+const EventCard: FC<{ event: Event }> = ({ event }) => {
+  const date = event.event_date ? new Date(event.event_date).toLocaleDateString() : null;
+
+  return (
+    <div className="p-4 border rounded shadow-sm bg-background">
+      <h2 className="text-lg font-semibold mb-1">{event.name}</h2>
+      {date && <p className="text-xs mb-1 text-gray-500">{date}</p>}
+      <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{event.description}</p>
+      <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
+        {tierLabels[event.tier] || 'Unknown'} tier
+      </span>
+    </div>
+  );
+};
+
+export default EventCard;


### PR DESCRIPTION
## Summary
- guard events page with Clerk `useAuth`
- fetch tier-specific events from Supabase and render `EventCard` grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dff652f108321aabdd907922f0a5a