### PR TITLE
feat: add shared layout with navbar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
-import Navbar from "@/components/Navbar";
+import Layout from "@/components/Layout";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,8 +30,7 @@ export default function RootLayout({
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
-          <Navbar />
-          {children}
+          <Layout>{children}</Layout>
         </body>
       </html>
     </ClerkProvider>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,15 @@
+import Navbar from "@/components/Navbar";
+import React from "react";
+
+export default function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <Navbar />
+      <main>{children}</main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable Layout component that includes Navbar
- apply Layout in app's root layout for consistent navigation

## Testing
- `npm test`
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688e022d4b848321bc473b6a0e36f7a6