### PR TITLE
Protect events page and load tiered events

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,0 +1,25 @@
+interface EventCardProps {
+  event: {
+    id: number;
+    name: string;
+    description: string;
+    tier: number;
+  };
+}
+
+const tierLabels = ['Free', 'Silver', 'Gold', 'Platinum'];
+
+export default function EventCard({ event }: EventCardProps) {
+  return (
+    <div className="p-4 border rounded shadow-sm bg-background">
+      <h2 className="text-lg font-semibold mb-1">{event.name}</h2>
+      <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
+        {event.description}
+      </p>
+      <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
+        {tierLabels[event.tier] ?? event.tier} tier
+      </span>
+    </div>
+  );
+}
+

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -1,56 +1,85 @@
 'use client';
 
-import { useUser } from "@clerk/nextjs";
-import events, { Tier } from "@/data/events";
-import Spinner from "@/components/Spinner";
+import { useEffect, useState } from 'react';
+import { useAuth, useUser } from '@clerk/nextjs';
+import { useRouter } from 'next/navigation';
 
-const tierRank: Record<Tier, number> = {
+import Spinner from '@/components/Spinner';
+import ErrorMessage from '@/components/ErrorMessage';
+import EventCard from '@/components/EventCard';
+import { getEventsForTier } from '@/lib/events';
+
+const tierRank: Record<string, number> = {
   Free: 0,
   Silver: 1,
   Gold: 2,
   Platinum: 3,
 };
 
-export default function EventShowcase() {
-  const { user, isLoaded, isSignedIn } = useUser();
+interface Event {
+  id: number;
+  name: string;
+  description: string;
+  tier: number;
+}
 
-  if (!isLoaded) {
+export default function EventShowcase() {
+  const { isLoaded: authLoaded, userId } = useAuth();
+  const { user, isLoaded: userLoaded } = useUser();
+  const router = useRouter();
+
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadEvents = async () => {
+    if (!user) return;
+    const tierName = (user.publicMetadata?.tier as string) || 'Free';
+    const userTier = tierRank[tierName] ?? 0;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getEventsForTier(userTier);
+      setEvents(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!authLoaded || !userLoaded) return;
+    if (!userId) {
+      router.push('/sign-in');
+      return;
+    }
+    loadEvents();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authLoaded, userLoaded, userId]);
+
+  if (!authLoaded || !userLoaded || loading) {
     return <Spinner />;
   }
 
-  const tier: Tier =
-    (isSignedIn ? (user?.publicMetadata?.tier as Tier) : undefined) ?? "Free";
-
-  const filtered = events.filter(
-    (event) => tierRank[event.tier] <= tierRank[tier]
-  );
+  if (error) {
+    return <ErrorMessage message={error} onRetry={loadEvents} />;
+  }
 
   return (
     <div className="p-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
-      <p className="mb-6 text-center">
-        Showing events for tier: <span className="font-medium">{tier}</span>
-      </p>
-      <ul className="grid gap-4">
-        {filtered.length ? (
-          filtered.map((event) => (
-            <li
-              key={event.id}
-              className="p-4 border rounded shadow-sm bg-background"
-            >
-              <h2 className="text-lg font-semibold mb-1">{event.name}</h2>
-              <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
-                {event.description}
-              </p>
-              <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-                {event.tier} tier
-              </span>
-            </li>
-          ))
-        ) : (
-          <li>No events available for your tier.</li>
-        )}
-      </ul>
+      {events.length === 0 ? (
+        <p className="text-center">No events available for your tier.</p>
+      ) : (
+        <div className="grid gap-4">
+          {events.map((event) => (
+            <EventCard key={event.id} event={event} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- guard events route with `useAuth` and fetch events for user tier
- show spinner, error message, and empty state as needed
- render events with reusable `EventCard`

## Testing
- `npm test`
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688dff652f108321aabdd907922f0a5a