### PR TITLE
Add global error boundary component

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
 import Navbar from "@/components/Navbar";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,11 +28,11 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en">
-        <body
-          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-        >
-          <Navbar />
-          {children}
+        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+          <ErrorBoundary>
+            <Navbar />
+            {children}
+          </ErrorBoundary>
         </body>
       </html>
     </ClerkProvider>

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import ErrorMessage from '@/components/ErrorMessage';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export default class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+    this.handleRetry = this.handleRetry.bind(this);
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error(error, errorInfo);
+  }
+
+  handleRetry() {
+    this.setState({ hasError: false, error: undefined });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorMessage
+          message={this.state.error?.message}
+          onRetry={this.handleRetry}
+        />
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable ErrorBoundary component that shows a retryable fallback UI
- wrap application layout with the new error boundary to handle runtime failures

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688e0776d5e483218e617fb787d0ffce