### PR TITLE
feat: improve responsive grid

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -68,7 +68,7 @@ export default function EventsPage() {
   return (
     <div className="p-4 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
-      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {events.map((event) => (
           <EventCard key={event.id} event={event} />
         ))}

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -31,7 +31,7 @@ export default function EventShowcase() {
       <p className="mb-6 text-center">
         Showing events for tier: <span className="font-medium">{tier}</span>
       </p>
-      <ul className="grid gap-4">
+      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {filtered.length ? (
           filtered.map((event) => (
             <li


### PR DESCRIPTION
## Summary
- ensure responsive grid layout uses 1/2/3 columns for mobile, small, and medium screens

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688e096b00a48321afcbc23b9ae414af