### PR TITLE
test: add jest unit tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/test/setupTests.ts'],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,21 +7,26 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "rm -rf build && tsc data/events.ts test/events.test.ts --module commonjs --target ES2017 --outDir build --esModuleInterop --noEmit false && node build/test/events.test.js"
+    "test": "jest"
   },
   "dependencies": {
     "@clerk/nextjs": "^5",
     "@supabase/supabase-js": "^2.0.0",
     "next": "15.4.5",
-      "react": "19.1.0",
-      "react-dom": "19.1.0"
-    },
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
   "devDependencies": {
-    "typescript": "^5",
+    "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^16.3.0",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4"
+    "jest": "^29.7.0",
+    "tailwindcss": "^4",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5"
   }
 }

--- a/test/ErrorMessage.test.tsx
+++ b/test/ErrorMessage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorMessage from '../components/ErrorMessage';
+
+describe('ErrorMessage', () => {
+  it('shows message and triggers retry', () => {
+    const onRetry = jest.fn();
+    render(<ErrorMessage message="Custom error" onRetry={onRetry} />);
+
+    expect(screen.getByText('Custom error')).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /try again/i });
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('renders without retry button when none provided', () => {
+    render(<ErrorMessage />);
+    expect(
+      screen.getByText('Something went wrong.')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/test/EventCard.test.tsx
+++ b/test/EventCard.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import EventCard, { Event } from '../components/EventCard';
+
+describe('EventCard', () => {
+  it('renders event details', () => {
+    const event: Event = {
+      id: 1,
+      name: 'Sample',
+      description: 'An event',
+      tier: 2,
+      event_date: '2024-05-15',
+    };
+
+    render(<EventCard event={event} />);
+
+    expect(screen.getByText('Sample')).toBeInTheDocument();
+    expect(screen.getByText('An event')).toBeInTheDocument();
+    expect(
+      screen.getByText(new Date('2024-05-15').toLocaleDateString())
+    ).toBeInTheDocument();
+    expect(screen.getByText('Gold tier')).toBeInTheDocument();
+  });
+});

--- a/test/Spinner.test.tsx
+++ b/test/Spinner.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Spinner from '../components/Spinner';
+
+describe('Spinner', () => {
+  it('renders with status role', () => {
+    render(<Spinner />);
+    const spinner = screen.getByRole('status', { name: /loading/i });
+    expect(spinner).toBeInTheDocument();
+  });
+});

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,12 +1,15 @@
-import assert from 'node:assert';
 import events, { Tier } from '../data/events';
 
-const tiers: Tier[] = ['Free', 'Silver', 'Gold', 'Platinum'];
+describe('events data', () => {
+  const tiers: Tier[] = ['Free', 'Silver', 'Gold', 'Platinum'];
 
-assert.strictEqual(events.length, 6, 'expected six events');
+  it('contains six events', () => {
+    expect(events).toHaveLength(6);
+  });
 
-for (const event of events) {
-  assert.ok(tiers.includes(event.tier), `invalid tier for event ${event.id}`);
-}
-
-console.log('All tests passed');
+  it('only uses valid tiers', () => {
+    for (const event of events) {
+      expect(tiers).toContain(event.tier);
+    }
+  });
+});

--- a/test/getEventsForTier.test.ts
+++ b/test/getEventsForTier.test.ts
@@ -1,0 +1,57 @@
+describe('getEventsForTier', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    delete (global as any).fetch;
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  });
+
+  it('throws if missing configuration', async () => {
+    jest.resetModules();
+    const { getEventsForTier } = await import('../lib/events');
+    await expect(getEventsForTier(1)).rejects.toThrow('Missing Supabase configuration');
+  });
+
+  it('fetches events with correct headers', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    const mockData = [{ id: 1, name: 'Test', description: 'Desc', tier: 1 }];
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockData),
+    });
+    (global as any).fetch = mockFetch;
+
+    jest.resetModules();
+    const { getEventsForTier } = await import('../lib/events');
+    const data = await getEventsForTier(1);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://supabase.test/rest/v1/events?select=*&tier=lte.1&order=event_date.asc',
+      {
+        headers: {
+          apikey: 'anon',
+          Authorization: 'Bearer anon',
+        },
+      }
+    );
+    expect(data).toEqual(mockData);
+  });
+
+  it('throws on Supabase error', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://supabase.test';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: jest.fn().mockResolvedValue('fail'),
+    });
+    (global as any).fetch = mockFetch;
+
+    jest.resetModules();
+    const { getEventsForTier } = await import('../lib/events');
+
+    await expect(getEventsForTier(1)).rejects.toThrow('Supabase error: 500 fail');
+  });
+});

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Jest config and setup
- add tests for getEventsForTier API helper
- add tests for EventCard, ErrorMessage, and Spinner components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e41d62ec48321a5b697e2fd922603