### PR TITLE
chore: configure next lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@types/react-dom": "^19",
     "@tailwindcss/postcss": "^4",
     "tailwindcss": "^4",
-    "cypress": "^13.6.2"
+    "cypress": "^13.6.2",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "15.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- add eslint config extending Next.js defaults
- include eslint and eslint-config-next as dev dependencies

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run build`
- `npm run test:e2e` *(fails: missing Xvfb)*


------
https://chatgpt.com/codex/tasks/task_e_688ef6236b508321a31c2457819e9b1d