### PR TITLE
Align schema with tiered event design

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -5,15 +5,9 @@ import { useAuth, useUser } from '@clerk/nextjs';
 import { useRouter } from 'next/navigation';
 import Spinner from '@/components/Spinner';
 import ErrorMessage from '@/components/ErrorMessage';
-import EventCard, { Event } from '@/components/EventCard';
+import EventCard from '@/components/EventCard';
+import { Event } from '@/data/events';
 import { getEventsForTier } from '@/lib/events';
-
-const tierMap: Record<string, number> = {
-  Free: 0,
-  Silver: 1,
-  Gold: 2,
-  Platinum: 3,
-};
 
 export default function EventsPage() {
   const { isLoaded, isSignedIn } = useAuth();
@@ -28,9 +22,8 @@ export default function EventsPage() {
     try {
       setError(null);
       setLoading(true);
-      const tierName = (user?.publicMetadata?.tier as string) || 'Free';
-      const tierValue = tierMap[tierName] ?? 0;
-      const data = await getEventsForTier(tierValue);
+      const tierName = ((user?.publicMetadata?.tier as string) || 'free').toLowerCase();
+      const data = await getEventsForTier(tierName);
       setEvents(data);
     } catch (err) {
       setError((err as Error).message);

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,25 +1,17 @@
 import { FC } from 'react';
-
-export interface Event {
-  id: number;
-  name: string;
-  description: string;
-  tier: number;
-  event_date?: string;
-}
-
-const tierLabels = ['Free', 'Silver', 'Gold', 'Platinum'];
+import { Event } from '@/data/events';
 
 const EventCard: FC<{ event: Event }> = ({ event }) => {
-  const date = event.event_date ? new Date(event.event_date).toLocaleDateString() : null;
+  const date = new Date(event.event_date).toLocaleDateString();
+  const tierLabel = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
 
   return (
     <div className="p-4 border rounded shadow-sm bg-background">
-      <h2 className="text-lg font-semibold mb-1">{event.name}</h2>
-      {date && <p className="text-xs mb-1 text-gray-500">{date}</p>}
+      <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
+      <p className="text-xs mb-1 text-gray-500">{date}</p>
       <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{event.description}</p>
       <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-        {tierLabels[event.tier] || 'Unknown'} tier
+        {tierLabel} tier
       </span>
     </div>
   );

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -5,10 +5,10 @@ import events, { Tier } from "@/data/events";
 import Spinner from "@/components/Spinner";
 
 const tierRank: Record<Tier, number> = {
-  Free: 0,
-  Silver: 1,
-  Gold: 2,
-  Platinum: 3,
+  free: 0,
+  silver: 1,
+  gold: 2,
+  platinum: 3,
 };
 
 export default function EventShowcase() {
@@ -19,34 +19,41 @@ export default function EventShowcase() {
   }
 
   const tier: Tier =
-    (isSignedIn ? (user?.publicMetadata?.tier as Tier) : undefined) ?? "Free";
+    (isSignedIn
+      ? ((user?.publicMetadata?.tier as string)?.toLowerCase() as Tier)
+      : undefined) ?? "free";
 
   const filtered = events.filter(
     (event) => tierRank[event.tier] <= tierRank[tier]
   );
 
+  const tierLabel = tier.charAt(0).toUpperCase() + tier.slice(1);
+
   return (
     <div className="p-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
       <p className="mb-6 text-center">
-        Showing events for tier: <span className="font-medium">{tier}</span>
+        Showing events for tier: <span className="font-medium">{tierLabel}</span>
       </p>
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {filtered.length ? (
-          filtered.map((event) => (
-            <li
-              key={event.id}
-              className="p-4 border rounded shadow-sm bg-background"
-            >
-              <h2 className="text-lg font-semibold mb-1">{event.name}</h2>
-              <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
-                {event.description}
-              </p>
-              <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-                {event.tier} tier
-              </span>
-            </li>
-          ))
+          filtered.map((event) => {
+            const label = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
+            return (
+              <li
+                key={event.id}
+                className="p-4 border rounded shadow-sm bg-background"
+              >
+                <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
+                <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
+                  {event.description}
+                </p>
+                <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
+                  {label} tier
+                </span>
+              </li>
+            );
+          })
         ) : (
           <li>No events available for your tier.</li>
         )}

--- a/cypress/e2e/event-visibility.cy.ts
+++ b/cypress/e2e/event-visibility.cy.ts
@@ -1,27 +1,27 @@
 import events, { Tier } from '../../data/events';
 
 const tierRank: Record<Tier, number> = {
-  Free: 0,
-  Silver: 1,
-  Gold: 2,
-  Platinum: 3,
+  free: 0,
+  silver: 1,
+  gold: 2,
+  platinum: 3,
 };
 
 function visibleEvents(tier: Tier) {
   const rank = tierRank[tier];
-  return events.filter((e) => tierRank[e.tier] <= rank).map((e) => e.name);
+  return events.filter((e) => tierRank[e.tier] <= rank).map((e) => e.title);
 }
 
 describe('event visibility per tier', () => {
   it('only shows free events to free users', () => {
-    expect(visibleEvents('Free')).to.deep.equal([
+    expect(visibleEvents('free')).to.deep.equal([
       'Community Meetup',
       'All Hands Q&A',
     ]);
   });
 
   it('includes gold events for gold users but not platinum', () => {
-    const names = visibleEvents('Gold');
+    const names = visibleEvents('gold');
     expect(names).to.include('Gold Hackathon');
     expect(names).not.to.include('Platinum Retreat');
   });

--- a/data/events.ts
+++ b/data/events.ts
@@ -1,48 +1,62 @@
-export type Tier = 'Free' | 'Silver' | 'Gold' | 'Platinum';
+export type Tier = 'free' | 'silver' | 'gold' | 'platinum';
 
 export interface Event {
-  id: number;
-  name: string;
-  description: string;
+  id: string;
+  title: string;
+  description?: string;
+  event_date: string;
+  image_url?: string;
   tier: Tier;
 }
 
 const events: Event[] = [
   {
-    id: 1,
-    name: 'Community Meetup',
+    id: '00000000-0000-0000-0000-000000000001',
+    title: 'Community Meetup',
     description: 'Meet fellow members at our free meetup.',
-    tier: 'Free',
+    event_date: '2025-09-01',
+    image_url: 'https://example.com/images/free1.jpg',
+    tier: 'free',
   },
   {
-    id: 2,
-    name: 'Silver Webinar',
-    description: 'Exclusive webinar for Silver members.',
-    tier: 'Silver',
+    id: '00000000-0000-0000-0000-000000000002',
+    title: 'Silver Webinar',
+    description: 'Exclusive webinar for silver members.',
+    event_date: '2025-10-05',
+    image_url: 'https://example.com/images/silver1.jpg',
+    tier: 'silver',
   },
   {
-    id: 3,
-    name: 'Gold Hackathon',
+    id: '00000000-0000-0000-0000-000000000003',
+    title: 'Gold Hackathon',
     description: 'Join our 24h hackathon and win prizes.',
-    tier: 'Gold',
+    event_date: '2025-11-10',
+    image_url: 'https://example.com/images/gold1.jpg',
+    tier: 'gold',
   },
   {
-    id: 4,
-    name: 'Platinum Retreat',
-    description: 'A weekend retreat for our Platinum members.',
-    tier: 'Platinum',
+    id: '00000000-0000-0000-0000-000000000004',
+    title: 'Platinum Retreat',
+    description: 'A weekend retreat for our platinum members.',
+    event_date: '2025-12-05',
+    image_url: 'https://example.com/images/platinum1.jpg',
+    tier: 'platinum',
   },
   {
-    id: 5,
-    name: 'All Hands Q&A',
+    id: '00000000-0000-0000-0000-000000000005',
+    title: 'All Hands Q&A',
     description: 'Monthly Q&A open for all tiers.',
-    tier: 'Free',
+    event_date: '2025-09-20',
+    image_url: 'https://example.com/images/free2.jpg',
+    tier: 'free',
   },
   {
-    id: 6,
-    name: 'Gold+ Networking Night',
-    description: 'Networking event for Gold and Platinum.',
-    tier: 'Gold',
+    id: '00000000-0000-0000-0000-000000000006',
+    title: 'Gold+ Networking Night',
+    description: 'Networking event for gold and platinum.',
+    event_date: '2025-11-25',
+    image_url: 'https://example.com/images/gold2.jpg',
+    tier: 'gold',
   },
 ];
 

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,7 +1,7 @@
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-export async function getEventsForTier(userTier: number) {
+export async function getEventsForTier(userTier: string) {
   if (!supabaseUrl || !supabaseAnonKey) {
     throw new Error('Missing Supabase configuration');
   }

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -8,10 +8,10 @@ alter table public.events enable row level security;
 create or replace function public.tier_rank(t text)
 returns int as $$
   select case t
-    when 'Free' then 1
-    when 'Silver' then 2
-    when 'Gold' then 3
-    when 'Platinum' then 4
+    when 'free' then 1
+    when 'silver' then 2
+    when 'gold' then 3
+    when 'platinum' then 4
     else 0
   end;
 $$ language sql immutable;
@@ -21,5 +21,5 @@ create policy tier_based_select
 on public.events
 for select
 using (
-  tier_rank(tier) <= tier_rank(coalesce(auth.jwt() ->> 'tier', 'Free'))
+  tier_rank(tier) <= tier_rank(coalesce(auth.jwt() ->> 'tier', 'free'))
 );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -12,8 +12,9 @@ create type tier_enum as enum (
 -- Events table storing tiered events
 create table events (
   id uuid primary key default uuid_generate_v4(),
-  name text not null,
-  description text not null,
-  tier tier_enum not null,
-  created_at timestamptz not null default now()
+  title text not null,
+  description text,
+  event_date timestamp not null,
+  image_url text,
+  tier tier_enum not null
 );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,9 +1,9 @@
 insert into public.events (title, description, tier, event_date, image_url) values
-  ('Community Kickoff', 'Meet fellow free members.', 'Free', '2025-09-01', 'https://example.com/images/free1.jpg'),
-  ('Open Source Sprint', 'Collaborate on open source projects.', 'Free', '2025-09-15', 'https://example.com/images/free2.jpg'),
-  ('Silver Strategy Session', 'Exclusive webinar for Silver tier.', 'Silver', '2025-10-05', 'https://example.com/images/silver1.jpg'),
-  ('Silver Networking Hour', 'Connect with peers at this virtual event.', 'Silver', '2025-10-20', 'https://example.com/images/silver2.jpg'),
-  ('Gold Hackathon', '24-hour hackathon with prizes.', 'Gold', '2025-11-10', 'https://example.com/images/gold1.jpg'),
-  ('Gold Masterclass', 'Deep dive masterclass for Gold members.', 'Gold', '2025-11-25', 'https://example.com/images/gold2.jpg'),
-  ('Platinum Retreat', 'Weekend retreat for Platinum members.', 'Platinum', '2025-12-05', 'https://example.com/images/platinum1.jpg'),
-  ('Platinum Gala', 'End-of-year gala dinner.', 'Platinum', '2025-12-20', 'https://example.com/images/platinum2.jpg');
+  ('Community Kickoff', 'Meet fellow free members.', 'free', '2025-09-01', 'https://example.com/images/free1.jpg'),
+  ('Open Source Sprint', 'Collaborate on open source projects.', 'free', '2025-09-15', 'https://example.com/images/free2.jpg'),
+  ('Silver Strategy Session', 'Exclusive webinar for Silver tier.', 'silver', '2025-10-05', 'https://example.com/images/silver1.jpg'),
+  ('Silver Networking Hour', 'Connect with peers at this virtual event.', 'silver', '2025-10-20', 'https://example.com/images/silver2.jpg'),
+  ('Gold Hackathon', '24-hour hackathon with prizes.', 'gold', '2025-11-10', 'https://example.com/images/gold1.jpg'),
+  ('Gold Masterclass', 'Deep dive masterclass for Gold members.', 'gold', '2025-11-25', 'https://example.com/images/gold2.jpg'),
+  ('Platinum Retreat', 'Weekend retreat for Platinum members.', 'platinum', '2025-12-05', 'https://example.com/images/platinum1.jpg'),
+  ('Platinum Gala', 'End-of-year gala dinner.', 'platinum', '2025-12-20', 'https://example.com/images/platinum2.jpg');

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import events, { Tier } from '../data/events';
 
-const tiers: Tier[] = ['Free', 'Silver', 'Gold', 'Platinum'];
+const tiers: Tier[] = ['free', 'silver', 'gold', 'platinum'];
 
 assert.strictEqual(events.length, 6, 'expected six events');
 


### PR DESCRIPTION
## Summary
- expand event schema with title, event date, image URL and lowercase tier enum
- update event model, sample data and components to use new fields and tier strings
- query Supabase by tier name and adjust policies to rank lowercase tiers

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_688f05b34c208321952d6c866a4f1a42