### PR TITLE
Implement tier-based select policy

### DIFF
--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -1,25 +1,13 @@
 -- Supabase row level security for events
--- enable RLS and define tier-based select policy
+-- Enable RLS and define tier-based select policy
 
 -- Ensure row level security is on for the events table
 alter table public.events enable row level security;
 
--- Helper function to rank tiers for comparison
-create or replace function public.tier_rank(t text)
-returns int as $$
-  select case t
-    when 'free' then 1
-    when 'silver' then 2
-    when 'gold' then 3
-    when 'platinum' then 4
-    else 0
-  end;
-$$ language sql immutable;
-
--- Policy allowing users to see events at or below their tier
+-- Policy: Only allow users to select events at or below their tier
 create policy tier_based_select
 on public.events
 for select
 using (
-  tier_rank(tier) <= tier_rank(coalesce(auth.jwt() ->> 'tier', 'free'))
+  ((auth.jwt() ->> 'tier')::tier_enum >= tier)
 );


### PR DESCRIPTION
## Summary
- enable RLS for `public.events` and add `tier_based_select` policy restricting access to events at or below the user's tier

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_688f08c2a4f483218ec25c996a73129f