### PR TITLE
refactor: add frontend supabase helpers

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import Spinner from '@/components/Spinner';
 import ErrorMessage from '@/components/ErrorMessage';
 import EventCard from '@/components/EventCard';
-import { Event } from '@/data/events';
+import { Event, Tier } from '@/data/events';
 import { getEventsForTier } from '@/lib/events';
 
 export default function EventsPage() {
@@ -23,8 +23,9 @@ export default function EventsPage() {
       setError(null);
       setLoading(true);
       const tierName = ((user?.publicMetadata?.tier as string) || 'free').toLowerCase();
-      const data = await getEventsForTier(tierName);
-      setEvents(data);
+      const { data, error } = await getEventsForTier(tierName as Tier);
+      if (error) throw error;
+      setEvents(data || []);
     } catch (err) {
       setError((err as Error).message);
     } finally {

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,25 +1,11 @@
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+import { supabase } from './supabaseClient';
+import { Tier } from '@/data/events';
 
-export async function getEventsForTier(userTier: string) {
-  if (!supabaseUrl || !supabaseAnonKey) {
-    throw new Error('Missing Supabase configuration');
-  }
-
-  const queryUrl = `${supabaseUrl}/rest/v1/events?select=*&tier=lte.${userTier}&order=event_date.asc`;
-
-  const res = await fetch(queryUrl, {
-    headers: {
-      apikey: supabaseAnonKey,
-      Authorization: `Bearer ${supabaseAnonKey}`,
-    },
-  });
-
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(`Supabase error: ${res.status} ${message}`);
-  }
-
-  return res.json();
+export async function getEventsForTier(userTier: Tier) {
+  const { data, error } = await supabase
+    .from('events')
+    .select('*')
+    .lte('tier', userTier)
+    .order('event_date', { ascending: true });
+  return { data, error };
 }
-

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
 


### PR DESCRIPTION
## Summary
- create shared Supabase client for frontend
- fetch events via Supabase client with tier filtering
- update events page to handle new helper output

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688f0ca1a54483218b09800b76004a8f