### PR TITLE
feat: add tier badge for events

### DIFF
--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -1,0 +1,9 @@
+export default function UpgradePage() {
+  return (
+    <div className="p-4 max-w-md mx-auto text-center">
+      <h1 className="text-2xl font-bold mb-4">Upgrade Tier</h1>
+      <p>Tier upgrade form coming soon.</p>
+    </div>
+  );
+}
+

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,20 +1,19 @@
 import { FC } from 'react';
 import { Event } from '@/data/events';
+import TierBadge from './TierBadge';
 
 const EventCard: FC<{ event: Event }> = ({ event }) => {
   const date = new Date(event.event_date).toLocaleDateString();
-  const tierLabel = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
 
   return (
     <div className="p-4 border rounded shadow-sm bg-background">
       <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
       <p className="text-xs mb-1 text-gray-500">{date}</p>
       <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{event.description}</p>
-      <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-        {tierLabel} tier
-      </span>
+      <TierBadge tier={event.tier} />
     </div>
   );
 };
 
 export default EventCard;
+

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -3,6 +3,7 @@
 import { useUser } from "@clerk/nextjs";
 import events, { Tier } from "@/data/events";
 import Spinner from "@/components/Spinner";
+import TierBadge from "./TierBadge";
 
 const tierRank: Record<Tier, number> = {
   free: 0,
@@ -37,23 +38,18 @@ export default function EventShowcase() {
       </p>
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {filtered.length ? (
-          filtered.map((event) => {
-            const label = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
-            return (
-              <li
-                key={event.id}
-                className="p-4 border rounded shadow-sm bg-background"
-              >
-                <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
-                <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
-                  {event.description}
-                </p>
-                <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-                  {label} tier
-                </span>
-              </li>
-            );
-          })
+          filtered.map((event) => (
+            <li
+              key={event.id}
+              className="p-4 border rounded shadow-sm bg-background"
+            >
+              <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
+              <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
+                {event.description}
+              </p>
+              <TierBadge tier={event.tier} />
+            </li>
+          ))
         ) : (
           <li>No events available for your tier.</li>
         )}
@@ -61,3 +57,4 @@ export default function EventShowcase() {
     </div>
   );
 }
+

--- a/components/TierBadge.tsx
+++ b/components/TierBadge.tsx
@@ -1,0 +1,18 @@
+import { Tier } from '@/data/events';
+
+const tierStyles: Record<Tier, string> = {
+  free: 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  silver: 'bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-gray-200',
+  gold: 'bg-yellow-200 text-yellow-800 dark:bg-yellow-600 dark:text-yellow-100',
+  platinum: 'bg-indigo-200 text-indigo-800 dark:bg-indigo-600 dark:text-indigo-100',
+};
+
+export default function TierBadge({ tier }: { tier: Tier }) {
+  const label = tier.charAt(0).toUpperCase() + tier.slice(1);
+  return (
+    <span className={`text-xs px-2 py-1 rounded ${tierStyles[tier]}`}>
+      {label} tier
+    </span>
+  );
+}
+


### PR DESCRIPTION
## Summary
- display tier using new TierBadge component
- add placeholder upgrade page

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688f0e7e6e748321a814dd25251b5516