### PR TITLE
feat: add tiered event display and upgrade flow

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -7,7 +7,7 @@ import Spinner from '@/components/Spinner';
 import ErrorMessage from '@/components/ErrorMessage';
 import EventCard from '@/components/EventCard';
 import { Event, Tier } from '@/data/events';
-import { getEventsForTier } from '@/lib/events';
+import { getAllEvents } from '@/lib/events';
 
 export default function EventsPage() {
   const { isLoaded, isSignedIn } = useAuth();
@@ -22,8 +22,7 @@ export default function EventsPage() {
     try {
       setError(null);
       setLoading(true);
-      const tierName = ((user?.publicMetadata?.tier as string) || 'free').toLowerCase();
-      const { data, error } = await getEventsForTier(tierName as Tier);
+      const { data, error } = await getAllEvents();
       if (error) throw error;
       setEvents(data || []);
     } catch (err) {
@@ -59,12 +58,14 @@ export default function EventsPage() {
     return <p className="p-4 text-center">No events available for your tier.</p>;
   }
 
+  const userTier = ((user?.publicMetadata?.tier as string) || 'free').toLowerCase() as Tier;
+
   return (
     <div className="p-4 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {events.map((event) => (
-          <EventCard key={event.id} event={event} />
+          <EventCard key={event.id} event={event} userTier={userTier} />
         ))}
       </div>
     </div>

--- a/app/upgrade/page.tsx
+++ b/app/upgrade/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useUser } from '@clerk/nextjs';
+import { Tier } from '@/data/events';
+
+const tiers: Tier[] = ['silver', 'gold', 'platinum'];
+
+export default function UpgradePage() {
+  const { user } = useUser();
+  const router = useRouter();
+  const [tier, setTier] = useState<Tier>('silver');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUpgrade = async () => {
+    if (!user) return;
+    try {
+      setError(null);
+      setLoading(true);
+      await user.update({ publicMetadata: { tier } });
+      router.push('/events');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4 text-center">Upgrade</h1>
+      <select
+        value={tier}
+        onChange={(e) => setTier(e.target.value as Tier)}
+        className="w-full border p-2 mb-4 rounded"
+      >
+        {tiers.map((t) => (
+          <option key={t} value={t}>
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </option>
+        ))}
+      </select>
+      <button
+        onClick={handleUpgrade}
+        disabled={loading}
+        className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+      >
+        {loading ? 'Upgrading...' : 'Upgrade'}
+      </button>
+      {error && <p className="text-red-500 mt-2 text-sm">{error}</p>}
+    </div>
+  );
+}
+

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,18 +1,54 @@
+import Image from 'next/image';
+import Link from 'next/link';
 import { FC } from 'react';
-import { Event } from '@/data/events';
+import { Event, Tier } from '@/data/events';
 
-const EventCard: FC<{ event: Event }> = ({ event }) => {
+const tierOrder: Tier[] = ['free', 'silver', 'gold', 'platinum'];
+
+interface EventCardProps {
+  event: Event;
+  userTier: Tier;
+}
+
+const EventCard: FC<EventCardProps> = ({ event, userTier }) => {
   const date = new Date(event.event_date).toLocaleDateString();
   const tierLabel = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
+  const isLocked = tierOrder.indexOf(event.tier) > tierOrder.indexOf(userTier);
+  const description = event.description
+    ? event.description.length > 100
+      ? event.description.slice(0, 100) + '...'
+      : event.description
+    : '';
 
   return (
-    <div className="p-4 border rounded shadow-sm bg-background">
-      <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
-      <p className="text-xs mb-1 text-gray-500">{date}</p>
-      <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{event.description}</p>
-      <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-        {tierLabel} tier
-      </span>
+    <div className="relative overflow-hidden rounded border shadow-sm bg-background">
+      <Image
+        src={event.image_url || '/file.svg'}
+        alt={event.title}
+        width={400}
+        height={200}
+        className="w-full h-40 object-cover"
+      />
+      <div className="p-4">
+        <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
+        <p className="text-xs mb-1 text-gray-500">{date}</p>
+        {description && (
+          <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{description}</p>
+        )}
+        <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
+          {tierLabel} tier
+        </span>
+      </div>
+      {isLocked && (
+        <div className="absolute inset-0 flex items-center justify-center bg-white/70 backdrop-blur">
+          <Link
+            href="/upgrade"
+            className="px-3 py-1 text-sm rounded bg-blue-600 text-white hover:bg-blue-700"
+          >
+            Upgrade
+          </Link>
+        </div>
+      )}
     </div>
   );
 };

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,11 +1,10 @@
 import { supabase } from './supabaseClient';
-import { Tier } from '@/data/events';
 
-export async function getEventsForTier(userTier: Tier) {
+export async function getAllEvents() {
   const { data, error } = await supabase
     .from('events')
     .select('*')
-    .lte('tier', userTier)
     .order('event_date', { ascending: true });
   return { data, error };
 }
+

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'example.com',
+        pathname: '/images/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- display event images, dates, descriptions, and tier badges with locked overlay for higher tiers
- fetch all events and add upgrade page for changing tiers
- allow remote example.com images in config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f10382cf083219a5295f407de1d62