### PR TITLE
feat: add tier color badge

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -1,18 +1,15 @@
 import { FC } from 'react';
 import { Event } from '@/data/events';
+import TierBadge from '@/components/TierBadge';
 
 const EventCard: FC<{ event: Event }> = ({ event }) => {
   const date = new Date(event.event_date).toLocaleDateString();
-  const tierLabel = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
-
   return (
     <div className="p-4 border rounded shadow-sm bg-background">
       <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
       <p className="text-xs mb-1 text-gray-500">{date}</p>
       <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{event.description}</p>
-      <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-        {tierLabel} tier
-      </span>
+      <TierBadge tier={event.tier} />
     </div>
   );
 };

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -3,6 +3,7 @@
 import { useUser } from "@clerk/nextjs";
 import events, { Tier } from "@/data/events";
 import Spinner from "@/components/Spinner";
+import TierBadge from "@/components/TierBadge";
 
 const tierRank: Record<Tier, number> = {
   free: 0,
@@ -37,23 +38,18 @@ export default function EventShowcase() {
       </p>
       <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         {filtered.length ? (
-          filtered.map((event) => {
-            const label = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
-            return (
-              <li
-                key={event.id}
-                className="p-4 border rounded shadow-sm bg-background"
-              >
-                <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
-                <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
-                  {event.description}
-                </p>
-                <span className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700">
-                  {label} tier
-                </span>
-              </li>
-            );
-          })
+          filtered.map((event) => (
+            <li
+              key={event.id}
+              className="p-4 border rounded shadow-sm bg-background"
+            >
+              <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
+              <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">
+                {event.description}
+              </p>
+              <TierBadge tier={event.tier} />
+            </li>
+          ))
         ) : (
           <li>No events available for your tier.</li>
         )}

--- a/components/TierBadge.tsx
+++ b/components/TierBadge.tsx
@@ -1,0 +1,20 @@
+import { FC } from 'react';
+import { Tier } from '@/data/events';
+
+const tierStyles: Record<Tier, string> = {
+  free: 'bg-gray-200 text-gray-800',
+  silver: 'bg-blue-100 text-blue-800',
+  gold: 'bg-yellow-100 text-yellow-800',
+  platinum: 'bg-purple-100 text-purple-800',
+};
+
+const TierBadge: FC<{ tier: Tier }> = ({ tier }) => {
+  const label = tier.charAt(0).toUpperCase() + tier.slice(1);
+  return (
+    <span className={`text-xs px-2 py-1 rounded ${tierStyles[tier]}`}>
+      {label} tier
+    </span>
+  );
+};
+
+export default TierBadge;


### PR DESCRIPTION
## Summary
- add TierBadge component with specific colors per tier
- use TierBadge in EventCard and EventShowcase

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688f10cbe344832187d89f16609afac0