### PR TITLE
Adjust grid and card spacing

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -62,7 +62,7 @@ export default function EventsPage() {
   return (
     <div className="p-4 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 p-4 sm:grid-cols-2 md:grid-cols-3">
         {events.map((event) => (
           <EventCard key={event.id} event={event} />
         ))}

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -6,7 +6,7 @@ const EventCard: FC<{ event: Event }> = ({ event }) => {
   const tierLabel = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
 
   return (
-    <div className="p-4 border rounded shadow-sm bg-background">
+    <div className="p-4 rounded-2xl shadow-md overflow-hidden bg-background">
       <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
       <p className="text-xs mb-1 text-gray-500">{date}</p>
       <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">{event.description}</p>

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -35,14 +35,14 @@ export default function EventShowcase() {
       <p className="mb-6 text-center">
         Showing events for tier: <span className="font-medium">{tierLabel}</span>
       </p>
-      <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <ul className="grid grid-cols-1 gap-6 p-4 sm:grid-cols-2 md:grid-cols-3">
         {filtered.length ? (
           filtered.map((event) => {
             const label = event.tier.charAt(0).toUpperCase() + event.tier.slice(1);
             return (
               <li
                 key={event.id}
-                className="p-4 border rounded shadow-sm bg-background"
+                className="p-4 rounded-2xl shadow-md overflow-hidden bg-background"
               >
                 <h2 className="text-lg font-semibold mb-1">{event.title}</h2>
                 <p className="text-sm mb-2 text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- increase grid gap and add padding for event listings
- give event cards larger rounding, shadow, and hidden overflow

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_688f10e5971c8321818f3b9c7fa43fc1