### PR TITLE
Handle missing external services

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useAuth, useUser } from '@clerk/nextjs';
+import { useAuth, useUser, clerkEnabled } from '@/lib/clerk';
 import { useRouter } from 'next/navigation';
 import Spinner from '@/components/Spinner';
 import ErrorMessage from '@/components/ErrorMessage';
@@ -34,6 +34,10 @@ export default function EventsPage() {
   };
 
   useEffect(() => {
+    if (!clerkEnabled) {
+      fetchEvents();
+      return;
+    }
     if (!isLoaded) return;
     if (!isSignedIn) {
       router.push('/sign-in?redirect_url=/events');
@@ -43,7 +47,7 @@ export default function EventsPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded, isSignedIn]);
 
-  if (!isLoaded || !isSignedIn) {
+  if (clerkEnabled && (!isLoaded || !isSignedIn)) {
     return <Spinner />;
   }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { ClerkProvider } from "@clerk/nextjs";
+import { ClerkProvider } from "@/lib/clerk";
 import Navbar from "@/components/Navbar";
 import ErrorBoundary from "@/components/ErrorBoundary";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from '@clerk/nextjs/server';
+import { auth } from '@/lib/clerkServer';
 import { redirect } from 'next/navigation';
 
 export default function Home() {

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,4 +1,4 @@
-import { SignIn } from '@clerk/nextjs';
+import { SignIn } from '@/lib/clerk';
 
 export default function Page() {
   return (

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,4 +1,4 @@
-import { SignUp } from '@clerk/nextjs';
+import { SignUp } from '@/lib/clerk';
 
 export default function Page() {
   return (

--- a/components/EventShowcase.tsx
+++ b/components/EventShowcase.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useUser } from "@clerk/nextjs";
+import { useUser } from "@/lib/clerk";
 import events, { Tier } from "@/data/events";
 import Spinner from "@/components/Spinner";
 import TierBadge from "./TierBadge";

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
-import { useUser, UserButton, SignOutButton } from '@clerk/nextjs';
+import { useUser, UserButton, SignOutButton } from '@/lib/clerk';
 
 export default function Navbar() {
   const { isSignedIn } = useUser();

--- a/lib/clerk.tsx
+++ b/lib/clerk.tsx
@@ -1,0 +1,52 @@
+import type { PropsWithChildren } from 'react';
+import {
+  ClerkProvider as RealClerkProvider,
+  SignIn as RealSignIn,
+  SignUp as RealSignUp,
+  SignOutButton as RealSignOutButton,
+  UserButton as RealUserButton,
+  useAuth as realUseAuth,
+  useUser as realUseUser,
+} from '@clerk/nextjs';
+
+const publishableKey =
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ||
+  process.env.CLERK_PUBLISHABLE_KEY;
+
+const enabled = Boolean(publishableKey);
+
+export function ClerkProvider({ children }: PropsWithChildren) {
+  if (!enabled) {
+    return <>{children}</>;
+  }
+  return (
+    <RealClerkProvider publishableKey={publishableKey!}>
+      {children}
+    </RealClerkProvider>
+  );
+}
+
+export const useAuth = enabled
+  ? realUseAuth
+  : () => ({ isLoaded: true, isSignedIn: false } as const);
+
+export const useUser = enabled
+  ? realUseUser
+  : () => ({ isLoaded: true, isSignedIn: false, user: undefined } as const);
+
+export const UserButton = enabled ? RealUserButton : () => null;
+
+export const SignOutButton = enabled
+  ? RealSignOutButton
+  : ({ children }: PropsWithChildren) => <>{children}</>;
+
+export const SignIn = enabled
+  ? RealSignIn
+  : () => <p>Sign-in unavailable</p>;
+
+export const SignUp = enabled
+  ? RealSignUp
+  : () => <p>Sign-up unavailable</p>;
+
+export const clerkEnabled = enabled;
+

--- a/lib/clerkServer.ts
+++ b/lib/clerkServer.ts
@@ -1,0 +1,12 @@
+import { auth as realAuth } from '@clerk/nextjs/server';
+
+const publishableKey =
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ||
+  process.env.CLERK_PUBLISHABLE_KEY;
+
+const enabled = Boolean(publishableKey);
+
+export const auth = enabled ? realAuth : () => ({ userId: null });
+
+export const clerkEnabled = enabled;
+

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,7 +1,18 @@
 import { supabase } from './supabaseClient';
-import { Tier } from '@/data/events';
+import eventsData, { Tier } from '@/data/events';
+
+// Order tiers so we can compare access levels when falling back to local data.
+const tierOrder: Tier[] = ['free', 'silver', 'gold', 'platinum'];
 
 export async function getEventsForTier(userTier: Tier) {
+  if (!supabase) {
+    const idx = tierOrder.indexOf(userTier);
+    const data = eventsData.filter(
+      (e) => tierOrder.indexOf(e.tier) <= idx,
+    );
+    return { data, error: null };
+  }
+
   const { data, error } = await supabase
     .from('events')
     .select('*')

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,7 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+// Only create a Supabase client when the required environment variables are
+// defined.  In deployments where Supabase is not configured (for example,
+// preview builds), this prevents the application from throwing a runtime error
+// during module evaluation.  Callers can check for a `null` client and fall back
+// to alternative data sources.
+export const supabase =
+  process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    ? createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      )
+    : null;
 


### PR DESCRIPTION
## Summary
- avoid Supabase client crash by only initializing when env vars exist
- add mock Clerk wrappers so the app works even without Clerk config
- load events from local data when Clerk or Supabase are absent

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f1c9359dc8321a1d341f134149c2b