### PR TITLE
Display event loading skeletons with error state retry

### DIFF
--- a/app/events/loading.tsx
+++ b/app/events/loading.tsx
@@ -1,5 +1,14 @@
-import Spinner from '@/components/Spinner';
+import EventCardSkeleton from '@/components/EventCardSkeleton';
 
 export default function Loading() {
-  return <Spinner />;
+  return (
+    <div className="p-4 max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <EventCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import Spinner from '@/components/Spinner';
 import ErrorMessage from '@/components/ErrorMessage';
 import EventCard from '@/components/EventCard';
+import EventCardSkeleton from '@/components/EventCardSkeleton';
 import { Event, Tier } from '@/data/events';
 import { getEventsForTier } from '@/lib/events';
 
@@ -48,7 +49,16 @@ export default function EventsPage() {
   }
 
   if (loading) {
-    return <Spinner />;
+    return (
+      <div className="p-4 max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold mb-4 text-center">Events</h1>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <EventCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    );
   }
 
   if (error) {

--- a/components/EventCardSkeleton.tsx
+++ b/components/EventCardSkeleton.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+
+const EventCardSkeleton: FC = () => {
+  return (
+    <div className="p-4 border rounded shadow-sm bg-background animate-pulse">
+      <div className="h-5 w-3/4 mb-2 bg-gray-300 dark:bg-gray-700 rounded" />
+      <div className="h-3 w-1/2 mb-2 bg-gray-200 dark:bg-gray-700 rounded" />
+      <div className="h-3 w-full mb-2 bg-gray-200 dark:bg-gray-700 rounded" />
+      <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded" />
+    </div>
+  );
+};
+
+export default EventCardSkeleton;


### PR DESCRIPTION
## Summary
- show 6 EventCard skeletons while events load
- keep empty and error states with retry button
- use skeletons for route-level loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f14ce84b483218c49905f10d75b16