### PR TITLE
feat: allow local events fallback

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,7 +1,23 @@
 import { supabase } from './supabaseClient';
-import { Tier } from '@/data/events';
+import events, { Tier, Event } from '@/data/events';
 
+const tierOrder: Tier[] = ['free', 'silver', 'gold', 'platinum'];
+
+// Fetch events for a given tier. If a Supabase client is not configured we
+// fall back to the local mock data defined in `data/events.ts` so the app can
+// still function during development or tests.
 export async function getEventsForTier(userTier: Tier) {
+  if (!supabase) {
+    const allowedIndex = tierOrder.indexOf(userTier);
+    const data: Event[] = events
+      .filter((event) => tierOrder.indexOf(event.tier) <= allowedIndex)
+      .sort(
+        (a, b) =>
+          new Date(a.event_date).getTime() - new Date(b.event_date).getTime(),
+      );
+    return { data, error: null };
+  }
+
   const { data, error } = await supabase
     .from('events')
     .select('*')

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,7 +1,11 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
+// Create the Supabase client only when credentials are provided. This avoids
+// runtime errors during tests or local demos where environment variables might
+// be missing.
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase: SupabaseClient | null =
+  url && anonKey ? createClient(url, anonKey) : null;
 


### PR DESCRIPTION
## Summary
- avoid runtime crashes when Supabase credentials are missing
- load and sort local mock events if Supabase isn't configured

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_688f28c1bb388321ba322efbfbfa71ce